### PR TITLE
Improve parsing RAML Types. Part I

### DIFF
--- a/SPEC_SUPPORT.md
+++ b/SPEC_SUPPORT.md
@@ -31,6 +31,36 @@ securedBy? | :warning: | Definition and merging support. Not fully tested though
 
 * [Raml Data Types](https://github.com/raml-org/raml-spec/blob/raml-10/versions/raml-10/raml-10.md/#raml-data-types)
 
+Property | Status | Comments
+---|---|---
+schema? | :white_check_mark: :warning: | Show deprecation notice when using RAML 1.0
+type?	| :white_check_mark: :warning: | Some inheritance and merging strategies might not work
+example? | :white_check_mark: :warning: | Should complain if both example and examples are present
+examples? | :white_check_mark: :warning: | Should complain if both example and examples are present
+displayName?	| :white_check_mark: |
+description?	| :white_check_mark: |
+(<annotationName>)? | :x: |
+
+  * [Object Data Types](https://github.com/raml-org/raml-spec/blob/raml-10/versions/raml-10/raml-10.md/#object-types)
+
+
+  Property | Status | Comments
+  ---|---|---
+  properties? | :white_check_mark: :warning: | Some property limitations. See properties
+  minProperties?	| :warning: | Not fully tested. Need examples
+  maxProperties? | :warning: | Not fully tested. Need examples
+  additionalProperties? | :warning: | Declaration works. Not fully tested
+  patternProperties? | :warning: | Declaration works. Not fully tested
+  discriminator?	| :x: |
+
+  Extra Feature | Status
+  ---|--
+  [Alternative Syntax](https://github.com/raml-org/raml-spec/blob/raml-10/versions/raml-10/raml-10.md/#alternative-syntax) | :white_check_mark:
+  [Inheritance](https://github.com/raml-org/raml-spec/blob/raml-10/versions/raml-10/raml-10.md/#inheritance) | :warning: See inheritance
+  [Map types](https://github.com/raml-org/raml-spec/blob/raml-10/versions/raml-10/raml-10.md/#map-types) | :x:
+
+  * [Array Types](https://github.com/raml-org/raml-spec/blob/raml-10/versions/raml-10/raml-10.md/#array-types)
+
 _TBC_
 
 * [Base URI and Base URI Parameters](https://github.com/raml-org/raml-spec/blob/raml-10/versions/raml-10/raml-10.md#base-uri-and-base-uri-parameters)

--- a/lib/brujula.rb
+++ b/lib/brujula.rb
@@ -34,6 +34,7 @@ require_relative 'brujula/mergers/map_object_merger'
 require_relative 'brujula/type_extender/resource'
 require_relative 'brujula/type_extender/resource_type'
 require_relative 'brujula/type_extender/method'
+require_relative 'brujula/type_extender/raml_type'
 
 # Definitions
 require_relative 'brujula/raml/definition'

--- a/lib/brujula/data_transformers/property_declaration.rb
+++ b/lib/brujula/data_transformers/property_declaration.rb
@@ -17,7 +17,9 @@ module Brujula
       def call
         data.each_with_object({}) do |(key, property), object|
           if property.is_a?(String) # data as type
-            object.merge!(key => { "type" => property })
+            object.merge!(key.gsub(/\?$/, "") => {
+              "type" => property, "required" => !key.to_s.end_with?("?")
+            })
           else
             object.merge!(key => property)
           end

--- a/lib/brujula/map_object.rb
+++ b/lib/brujula/map_object.rb
@@ -70,6 +70,8 @@ module Brujula
         Brujula::TypeExtender::Method.new(definition: child).call
       when Brujula::Raml::V1_0::ResourceType
         Brujula::TypeExtender::ResourceType.new(definition: child).call
+      when Brujula::Raml::V1_0::RamlType
+        Brujula::TypeExtender::RamlType.new(definition: child).call
       else
         child
       end

--- a/lib/brujula/object_parser.rb
+++ b/lib/brujula/object_parser.rb
@@ -33,10 +33,20 @@ module Brujula
     end
 
     def normalized_data
+      @normalized_data ||= apply_default_type(node_data)
+    end
+
+    def node_data
       return data unless external_data?
 
-      # TODO
       data.load_external_data(definition.root.base_dir)
+    end
+
+    def apply_default_type(data)
+      return data unless scheme.typed?
+      return data if data.key?("type")
+
+      data.merge("type" => scheme.default_type.to_s)
     end
 
     def external_data?
@@ -47,15 +57,10 @@ module Brujula
       @scheme ||= definition.class.scheme
     end
 
-    # Typed schemas must provide a type
-    def data_type
-      normalized_data.fetch('type', scheme.default_type)
-    end
-
     def scheme_keys
       return scheme.key_collection unless scheme.typed?
 
-      scheme.typed_keys(data_type)
+      scheme.typed_keys(normalized_data.fetch('type'))
     end
 
     def object_builder(key)

--- a/lib/brujula/raml/exceptions.rb
+++ b/lib/brujula/raml/exceptions.rb
@@ -2,5 +2,6 @@ module Brujula
   module Raml
     class RequiredProperty < StandardError; end
     class ObjectTypeNotFound < StandardError; end
+    class InvalidTypeReference < KeyError; end
   end
 end

--- a/lib/brujula/raml/v1_0/property.rb
+++ b/lib/brujula/raml/v1_0/property.rb
@@ -17,15 +17,15 @@ module Brujula
           key :enum, as: :array, unless_type_is: %w( file )
 
           # When Property is integer
-          key :minimum, as: :number, for_types: %( number integer )
-          key :maximum, as: :number, for_types: %( number integer )
+          key :minimum, as: :number, for_types: %w( number integer )
+          key :maximum, as: :number, for_types: %w( number integer )
           key :format, as: :string,
-              in: %( int32 int64 int long float double int16 int8 )
+              in: %w( int32 int64 int long float double int16 int8 )
 
           # When Property is string
-          key :pattern, as: :regexp, for_types: %( string )
-          key :min_length, as: :number, for_types: %( string )
-          key :max_length, as: :number, for_types: %( string )
+          key :pattern, as: :regexp, for_types: %w( string )
+          key :min_length, as: :number, for_types: %w( string )
+          key :max_length, as: :number, for_types: %w( string )
 
         end
       end

--- a/lib/brujula/raml/v1_0/raml_type.rb
+++ b/lib/brujula/raml/v1_0/raml_type.rb
@@ -3,7 +3,7 @@ module Brujula
     module V1_0
       class RamlType < Brujula::Object
         scheme typed: true, default_type: :object do
-          key :type,   as: :string
+          key :type,   as: :any
           key :schema, as: :string, deprecated: true
 
           key :properties, as: :map_object, children: :property,

--- a/lib/brujula/raml/v1_0/raml_type.rb
+++ b/lib/brujula/raml/v1_0/raml_type.rb
@@ -17,15 +17,15 @@ module Brujula
           key :examples, as: :any
 
           # When Property is integer
-          key :minimum, as: :number, for_types: %( number integer )
-          key :maximum, as: :number, for_types: %( number integer )
+          key :minimum, as: :number, for_types: %w( number integer )
+          key :maximum, as: :number, for_types: %w( number integer )
           key :format, as: :string,
-              in: %( int32 int64 int long float double int16 int8 )
+              in: %w( int32 int64 int long float double int16 int8 )
 
           # When Property is string
-          key :pattern, as: :regexp, for_types: %( string )
-          key :min_length, as: :number, for_types: %( string )
-          key :max_length, as: :number, for_types: %( string )
+          key :pattern, as: :regexp, for_types: %w( string )
+          key :min_length, as: :number, for_types: %w( string )
+          key :max_length, as: :number, for_types: %w( string )
 
 
           # include_type_keys

--- a/lib/brujula/scheme.rb
+++ b/lib/brujula/scheme.rb
@@ -30,7 +30,7 @@ module Brujula
       valid_keys?(data) || raise(Brujula::Raml::RequiredProperty) # && enough_data?(data))
     end
 
-    def typed_keys(type)
+    def typed_keys(type) # TODO
       keys.values.select do |brujula_key|
         brujula_key.valid_for_type?(type)
       end

--- a/lib/brujula/scheme.rb
+++ b/lib/brujula/scheme.rb
@@ -1,10 +1,8 @@
 module Brujula
   class Scheme
-    attr_reader :keys, :typed, :default_type, :reference,
-                :store_for_reference, :allow_any
+    attr_reader :keys, :typed, :default_type, :reference, :allow_any
 
     alias :typed? :typed
-    alias :store_object_for_reference? :store_for_reference
     alias :allow_any? :allow_any
 
     def initialize(klass, options = {}, block = nil)
@@ -13,7 +11,6 @@ module Brujula
       @keys                = {}
       @typed               = !!options[:typed]
       @default_type        = options[:default_type] || :string
-      @store_for_reference = !!options[:store_for_reference]
       @allow_any           = !!options[:allow_any]
 
       if options[:as]

--- a/lib/brujula/type_extender/raml_type.rb
+++ b/lib/brujula/type_extender/raml_type.rb
@@ -28,6 +28,9 @@ module Brujula
         else
           definition.root.types.fetch(definition.type)
         end
+      rescue KeyError => error
+        raise Brujula::Raml::InvalidTypeReference,
+          "The referenced type #{ definition.type } cannot be processed"
       end
     end
   end

--- a/lib/brujula/type_extender/raml_type.rb
+++ b/lib/brujula/type_extender/raml_type.rb
@@ -1,0 +1,34 @@
+module Brujula
+  module TypeExtender
+    class RamlType
+
+      RAML_TYPES = %w( object number string integer boolean date file )
+
+      attr_reader :definition
+
+      def initialize(definition:)
+        @definition = definition
+      end
+
+      def call
+        return definition unless custom_type?
+
+        Brujula::Mergers::ObjectMerger.new(
+          superinstance: reference_type, instance: definition
+        ).call
+      end
+
+      def custom_type?
+        ! RAML_TYPES.include?(definition.type)
+      end
+
+      def reference_type
+        if definition.parent.name == "types" # root types, not preloaded
+          definition.parent.fetch(definition.type)
+        else
+          definition.root.types.fetch(definition.type)
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/raml_spec/raml_type_spec.rb
+++ b/spec/integration/raml_spec/raml_type_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe 'Resource RAML SPEC examples', type: :raml_spec do
+  describe 'raml_type_property_declaration' do
+    let(:person) { raml.root.types.fetch('Person') }
+    subject { person }
+
+    its(:type) { is_expected.to eq('object') }
+
+    describe 'properties #name' do
+      subject { person.properties.fetch('name') }
+
+      its(:type)     { is_expected.to eq('string') }
+      its(:required) { is_expected.to eq(true) }
+    end
+
+    describe 'properties #age' do
+      subject { person.properties.fetch('age') }
+
+      its(:type)     { is_expected.to eq('number') }
+      its(:required) { is_expected.to eq(false) }
+    end
+  end
+end

--- a/spec/integration/raml_spec/raml_type_spec.rb
+++ b/spec/integration/raml_spec/raml_type_spec.rb
@@ -42,4 +42,38 @@ describe 'Resource RAML SPEC examples', type: :raml_spec do
       its(:required) { is_expected.to eq(false) }
     end
   end
+
+  describe 'raml_type_inheritance' do
+    describe 'Type Person' do
+      let(:person) { raml.root.types.fetch('Person') }
+      subject { person }
+
+      its(:type) { is_expected.to eq('object') }
+
+      describe 'properties #name' do
+        subject { person.properties.fetch('name') }
+
+        its(:type)     { is_expected.to eq('string') }
+      end
+    end
+
+    describe 'Type Employee' do
+      let(:person) { raml.root.types.fetch('Employee') }
+      subject { person }
+
+      its(:type) { is_expected.to eq('Person') }
+
+      describe 'properties #id' do
+        subject { person.properties.fetch('id') }
+
+        its(:type)     { is_expected.to eq('string') }
+      end
+
+      describe 'properties #name' do
+        subject { person.properties.fetch('name') }
+
+        its(:type)     { is_expected.to eq('string') }
+      end
+    end
+  end
 end

--- a/spec/integration/raml_spec/raml_type_spec.rb
+++ b/spec/integration/raml_spec/raml_type_spec.rb
@@ -21,4 +21,25 @@ describe 'Resource RAML SPEC examples', type: :raml_spec do
       its(:required) { is_expected.to eq(false) }
     end
   end
+
+  describe 'raml_type_property_declaration_alternative_syntax' do
+    let(:person) { raml.root.types.fetch('Person') }
+    subject { person }
+
+    its(:type) { is_expected.to eq('object') }
+
+    describe 'properties #name' do
+      subject { person.properties.fetch('name') }
+
+      its(:type)     { is_expected.to eq('string') }
+      its(:required) { is_expected.to eq(true) }
+    end
+
+    describe 'properties #age' do
+      subject { person.properties.fetch('age') }
+
+      its(:type)     { is_expected.to eq('number') }
+      its(:required) { is_expected.to eq(false) }
+    end
+  end
 end

--- a/spec/integration/raml_spec/raml_type_spec.rb
+++ b/spec/integration/raml_spec/raml_type_spec.rb
@@ -58,21 +58,74 @@ describe 'Resource RAML SPEC examples', type: :raml_spec do
     end
 
     describe 'Type Employee' do
-      let(:person) { raml.root.types.fetch('Employee') }
-      subject { person }
+      let(:employee) { raml.root.types.fetch('Employee') }
+      subject { employee }
 
       its(:type) { is_expected.to eq('Person') }
 
       describe 'properties #id' do
-        subject { person.properties.fetch('id') }
+        subject { employee.properties.fetch('id') }
 
         its(:type)     { is_expected.to eq('string') }
       end
 
       describe 'properties #name' do
-        subject { person.properties.fetch('name') }
+        subject { employee.properties.fetch('name') }
 
         its(:type)     { is_expected.to eq('string') }
+      end
+    end
+  end
+
+  describe 'raml_type_multiple_inheritance' do
+    describe 'Type Person' do
+      let(:person) { raml.root.types.fetch('Person') }
+      subject { person }
+
+      its(:type) { is_expected.to eq('object') }
+
+      describe 'properties #name' do
+        subject { person.properties.fetch('name') }
+
+        its(:type) { is_expected.to eq('string') }
+      end
+    end
+
+    describe 'Type EmailOwner' do
+      let(:email_owner) { raml.root.types.fetch('EmailOwner') }
+      subject { email_owner }
+
+      its(:type) { is_expected.to eq('object') }
+
+      describe 'properties #email' do
+        subject { email_owner.properties.fetch('email') }
+
+        its(:type) { is_expected.to eq('string') }
+      end
+    end
+
+    describe 'Type Employee' do
+      let(:employee) { raml.root.types.fetch('Employee') }
+      subject { employee }
+
+      its(:type) { is_expected.to eq([ "Person", "EmailOwner" ]) }
+
+      describe 'properties #id' do
+        subject { employee.properties.fetch('id') }
+
+        its(:type) { is_expected.to eq('string') }
+      end
+
+      describe 'properties #name' do
+        subject { employee.properties.fetch('name') }
+
+        its(:type) { is_expected.to eq('string') }
+      end
+
+      describe 'properties #email' do
+        subject { employee.properties.fetch('email') }
+
+        its(:type) { is_expected.to eq('string') }
       end
     end
   end

--- a/spec/support/fixtures/raml/raml_spec/raml_type_inheritance.raml
+++ b/spec/support/fixtures/raml/raml_spec/raml_type_inheritance.raml
@@ -1,0 +1,13 @@
+#%RAML 1.0
+title: My API With Types
+types:
+  Person:
+    type: object
+    properties:
+      name:
+        type: string
+  Employee:
+    type: Person
+    properties:
+      id:
+        type: string

--- a/spec/support/fixtures/raml/raml_spec/raml_type_multiple_inheritance.raml
+++ b/spec/support/fixtures/raml/raml_spec/raml_type_multiple_inheritance.raml
@@ -1,0 +1,15 @@
+#%RAML 1.0
+title: My API With Types
+types:
+  Person:
+    type: object
+    properties:
+      name: string
+  EmailOwner:
+    type: object
+    properties:
+      email: string
+  Employee:
+    type: [ Person, EmailOwner ]
+    properties:
+      id: string

--- a/spec/support/fixtures/raml/raml_spec/raml_type_property_declaration.raml
+++ b/spec/support/fixtures/raml/raml_spec/raml_type_property_declaration.raml
@@ -1,0 +1,11 @@
+#%RAML 1.0
+title: My API With Types
+types:
+  Person:
+    properties:
+      name:
+        required: true
+        type: string
+      age:
+        required: false
+        type: number

--- a/spec/support/fixtures/raml/raml_spec/raml_type_property_declaration_alternative_syntax.raml
+++ b/spec/support/fixtures/raml/raml_spec/raml_type_property_declaration_alternative_syntax.raml
@@ -1,0 +1,7 @@
+#%RAML 1.0
+title: My API With Types
+types:
+  Person:
+    properties:
+      name: string
+      age?: number


### PR DESCRIPTION
#### Description

Improve how RAML Types are parsed, and support the following features:
- Property and type declaration with alternative syntax.
- Simple and multiple inheritance.

Improve test coverage
