### PR TITLE
Fix simplecov exception

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,5 +1,4 @@
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
+require 'simplecov'
 
 SimpleCov.start do
   add_filter "/spec/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ rvm:
   - 2.1.1
   - 2.2.2
 script:
-  - bundle exec rake
+  - bundle exec rake && bundle exec codeclimate-test-reporter


### PR DESCRIPTION
Simplecov requires now to run the code climate reporter outside the actual rspec / cucumber run.

more info: https://github.com/codeclimate/ruby-test-reporter/blob/master/README.md